### PR TITLE
support for go 1.19

### DIFF
--- a/p_m_go1.13.go
+++ b/p_m_go1.13.go
@@ -15,8 +15,8 @@
 
 // This file may have been modified by CloudWeGo authors. (“CloudWeGo Modifications”). All CloudWeGo Modifications are Copyright 2021 CloudWeGo authors.
 
-//go:build gc && go1.13 && !go1.19
-// +build gc,go1.13,!go1.19
+//go:build gc && go1.13 && go1.19
+// +build gc,go1.13,go1.19
 
 package goid
 


### PR DESCRIPTION
![hSX0gngeMF](https://user-images.githubusercontent.com/8140244/177239760-9df196a1-2154-4046-9ad0-2ddc018cbce0.jpg)
the root cause is that it does't chose a p_m file in assembly phase, so miss the m_p offset.