### PR TITLE
pid: support Go 1.21

### DIFF
--- a/p_m_go1.19.go
+++ b/p_m_go1.19.go
@@ -13,8 +13,8 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-//go:build gc && go1.19 && !go1.21
-// +build gc,go1.19,!go1.21
+//go:build gc && go1.19 && !go1.22
+// +build gc,go1.19,!go1.22
 
 package goid
 


### PR DESCRIPTION
Tested with go1.21rc2:

> $ go version
> go version go1.21rc2 darwin/amd64
> $ go test github.com/choleraehyq/pid/...
> ok      github.com/choleraehyq/pid